### PR TITLE
Support for PTB and Canary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 build
+*.spec

--- a/discord_band.py
+++ b/discord_band.py
@@ -13,6 +13,7 @@ class DiscordBand:
         self.disable_timer = 0
         self.thread = Thread(target=self.run)
         self.thread.start()
+        self.versions = ["Discord", "Discord Canary", "Discord PTB"]
 
     def is_call_notification(self, notification: UserNotification) -> bool:
         try:
@@ -36,7 +37,8 @@ class DiscordBand:
         try:
             if hasattr(notification, "app_info"):
                 app_name = notification.app_info.display_info.display_name
-                if app_name == "Discord":
+                if app_name in self.versions:
+                    print('Notification from {app_name}')
                     return True
             return False
         except AttributeError:


### PR DESCRIPTION
Did a tweak on what name(s) it checks for in the notification.
Adds support for PTB and Canary Discord users and a debug message to tell which it came from.